### PR TITLE
Add ROI tracking functionality/API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python files.
 __pycache__
 *.egg-info
+.tox
 
 # NPM files.
 node_modules

--- a/annotation_tracker/rest.py
+++ b/annotation_tracker/rest.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import time
 
 import large_image
 import numpy as np
@@ -353,7 +354,10 @@ class AnnotationTrackerResource(Resource):
         meta = ImageItem().getMetadata(image)
         if not meta or "sizeX" not in meta:
             return None
+
+        # for output file names
         image_name = os.path.splitext(image["name"])[0]
+        now = time.strftime("%Y%m%d-%H%M%S")
 
         origin = pan_data["origin"]
         source_list = []
@@ -388,7 +392,7 @@ class AnnotationTrackerResource(Resource):
                     scale_image.addTile(nparray, x=scaled_x, y=scaled_y)
 
                 # write the scale_image to disk
-                file_name = f"zoom_{zoom}_{image_name}.tiff"
+                file_name = f"zoom_{zoom}_{image_name}_{now}.tiff"
                 file_path = os.path.join(tempdir, file_name)
                 scale_image.write(file_path, lossy=False)
 
@@ -426,7 +430,7 @@ class AnnotationTrackerResource(Resource):
                     }
                 )
 
-            file_name = f"composite_{image_name}.yml"
+            file_name = f"composite_{image_name}_{now}.yml"
             file_path = os.path.join(tempdir, file_name)
 
             with open(file_path, "w") as yml_file:

--- a/annotation_tracker/rest.py
+++ b/annotation_tracker/rest.py
@@ -274,7 +274,6 @@ class AnnotationTrackerResource(Resource):
                     nparray, mime = ImageItem().getRegion(
                         image,
                         region=region,
-                        resample=Image.Resampling.NEAREST,
                         scale={"magnification": effective_mag},
                         format=large_image.constants.TILE_FORMAT_NUMPY,
                     )
@@ -325,12 +324,16 @@ class AnnotationTrackerResource(Resource):
                             "y": int(position[1]),
                             "scale": upscale_factor,
                         },
-                        # # TODO: including band styles for multiple sources in the same tile can break compositing
-                        # 'params': {'style': {'bands': [
-                        #     {'palette': '#f00', 'band': 1},
-                        #     {'palette': '#0f0', 'band': 2},
-                        #     {'palette': '#00f', 'band': 3},
-                        # ]}}
+                        'params': {'style': {'bands': [
+                            {'palette': '#f00', 'band': 1},
+                            {'palette': '#0f0', 'band': 2},
+                            {'palette': '#00f', 'band': 3},
+                            {
+                                'palette': ['#fff0', '#ffff'],
+                                'band': 4,
+                                'composite': 'multiply'
+                            },
+                        ]}}
                     }
                 )
 

--- a/annotation_tracker/rest.py
+++ b/annotation_tracker/rest.py
@@ -7,6 +7,7 @@ from girder.api.describe import autoDescribeRoute, Description
 from .models import Activity
 
 from girder_large_image.models.image_item import ImageItem
+import large_image
 
 from PIL import Image
 import io
@@ -22,6 +23,7 @@ class AnnotationTrackerResource(Resource):
         self.route('POST', ('log', ), self.logActivity)
         self.route('GET', (), self.find)
         self.route('GET', ('pan_history', ), self.pan_history)
+        self.route('GET', ('pan_history_json', ), self.pan_history_json)
 
     @autoDescribeRoute(
         Description('Log activity to the database.')
@@ -98,68 +100,109 @@ class AnnotationTrackerResource(Resource):
             query['activity'] = activity
         return Activity().find(query, offset=offset, limit=limit, sort=sort)
 
-    @access.admin(scope=TokenScope.DATA_READ)
-    @autoDescribeRoute(
-        Description('Generate image thumbnail displaying HistomicsUI panning history.')
-        .param('sessionId', 'A session id', required=True)
-        .param('imageId', 'Image\'s item id', required=True)
-        .param('maxSize', 'Maximum size of the thumbnail image dimension',
-               dataType='integer', default=512, required=False)
-        .pagingParams(defaultSort='epochms', defaultSortDir=SortDir.DESCENDING)
-        .errorResponse()
-    )
-    def pan_history(self, sessionId, imageId, maxSize, limit, offset, sort):
+    def activity_rois(self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort):
+        """Get a list of pan events for a given image and time range."""
         query = {
-            'session': sessionId,      # sessionId probably isn't unique enough for what we want
             'currentImage': imageId,
+            'epochms': {'$gte': startTime, '$lte': endTime},
             'activity': 'pan',
-            'zoom': {'$type': 'int'},  # this can break when window is too large for low zooms, it'll be an arbitrary float
         }
-        events = Activity().find(query, offset=offset, limit=limit, sort=sort)
+        events = Activity().find(query, offset=offset, limit=limit, sort=sort, fields=['epochms', 'visibleArea', 'zoom'])
         if events.count() == 0:
             return None
 
-        image = ImageItem().findOne({'_id': ObjectId(imageId)})
-        item = ImageItem().getMetadata(image)
-        if not item or 'sizeX' not in item:
+        # filter out events that are not close to an integer zoom
+        def zoom_threshold(zoom):
+            return abs(zoom - round(zoom)) < zoomThreshold
+        events = [e for e in events if zoom_threshold(e['zoom'])]
+
+        return events
+
+    @access.admin(scope=TokenScope.DATA_READ)
+    @autoDescribeRoute(
+        Description('Generate image thumbnail displaying HistomicsUI panning history.')
+        .param('imageId', 'Image\'s item id', required=True)
+        .param('startTime', 'Start of timeframe to examine (epochms)', dataType='integer', required=True)
+        .param('endTime', 'End of timeframe to examine (epochms)', dataType='integer', required=True)
+        .param('zoomThreshold', 'Maximum distance zoom variable can be from an interger', dataType='float', default='0.001', required=False)
+        .pagingParams(defaultSort='epochms', defaultSortDir=SortDir.DESCENDING)
+        .errorResponse()
+    )
+    def pan_history(self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort):
+        events = self.activity_rois(imageId, startTime, endTime, zoomThreshold, limit, offset, sort)
+        if not events:
             return None
 
-        # TODO: getRegion
-        # get thumbnail
-        result = ImageItem().getThumbnail(image, checkAndCreate=False,
-                                          width=maxSize, height=maxSize, encoding='PNG')
-        imageData, imageMime = result
+        image = ImageItem().findOne({'_id': ObjectId(imageId)})
+        meta = ImageItem().getMetadata(image)
+        if not meta or 'sizeX' not in meta:
+            return None
 
-        source = Image.open(io.BytesIO(imageData))
-        width, height = source.size
-        scale = width / item['sizeX']
-        source.save('../annotation-tracker/image.png')
-
-        # create mask
-        background_opacity = 0.3
-        mask = np.zeros((height, width), dtype=np.uint8)
-        mask.fill(int(background_opacity * 255))
+        dest = large_image.new()
+        scales = {}
 
         for e in events:
-            visibleArea = e['visibleArea']
-            min_x, max_x = floor(scale * visibleArea['tl']['x']), ceil(scale * visibleArea['br']['x'])
-            min_y, max_y = floor(scale * visibleArea['tl']['y']), ceil(scale * visibleArea['br']['y'])
+            tl = e['visibleArea']['tl']
+            br = e['visibleArea']['br']
 
-            min_x, max_x = max(min_x, 0), min(max_x, width)
-            min_y, max_y = max(min_y, 0), min(max_y, height)
+            # assuming that we know the image size and can zero-out negative values
+            min_x, max_x = max(floor(tl['x']), 0), max(ceil(br['x']), 0)
+            min_y, max_y = max(floor(tl['y']), 0), max(ceil(br['y']), 0)
 
-            mask[min_y:max_y, min_x:max_x] = 255
+            zoom = e['zoom']
+            if zoom not in scales:
+                scales[zoom] = {
+                    'region': {'left': min_x, 'right': max_x, 'top': min_y, 'bottom': max_y},
+                    'mask': np.zeros((meta['sizeY'], meta['sizeX']), dtype='uint8')
+                }
+            else:
+                region = scales[zoom]['region']
+                scales[zoom]['region']['left']   = min(min_x, region['left'])
+                scales[zoom]['region']['right']  = max(max_x, region['right'])
+                scales[zoom]['region']['top']    = min(min_y, region['top'])
+                scales[zoom]['region']['bottom'] = max(max_y, region['bottom'])
 
-        # apply mask
-        mask_image = Image.fromarray(mask)
-        mask_image.save('../annotation-tracker/mask.png')
+            # set the mask for this region
+            scales[zoom]['mask'][min_y:max_y, min_x:max_x] = 1
 
-        masked_source = Image.composite(source, mask_image, mask_image)
-        masked_source.save('../annotation-tracker/masked.png')
+        for zoom in sorted(scales.keys()):
+            item = scales[zoom]
+            region = item['region']
 
-        masked_bytes = io.BytesIO()
-        masked_source.save(masked_bytes, format='PNG')
+            # assuming that the default scaling for the image is 20x (on zoom=4)
+            effective_mag = (meta.get('magnification', 20) / 2**4) * (2 ** zoom)
 
-        setResponseHeader('Content-Type', 'image/png')
+            nparray, mime_type = ImageItem().getRegion(
+                image,
+                region=region,
+                resample=Image.Resampling.NEAREST,
+                scale={'magnification': effective_mag},
+                format=large_image.constants.TILE_FORMAT_NUMPY,
+            )
+
+            upscale_factor = 2 ** (meta['levels'] - 1 - zoom)
+            nparray = nparray.repeat(upscale_factor, axis=0).repeat(upscale_factor, axis=1)
+
+            mask = item['mask'][region['top']:region['bottom'], region['left']:region['right']]
+            mask = mask.copy() # copy to avoid modifying the original in resize
+            mask.resize(nparray.shape[:2])
+
+            dest.addTile(nparray, x=region['left'], y=region['top'], mask=mask)
+
+        data, mime = dest.getRegion()
+        setResponseHeader('Content-Type', mime)
         setRawResponse()
-        return masked_bytes.getvalue()
+        return data
+
+    @access.admin(scope=TokenScope.DATA_READ)
+    @autoDescribeRoute(
+        Description('Return JSON list of ROI bounding boxes for given image/timeframe.')
+        .param('imageId', 'Image\'s item id', required=True)
+        .param('startTime', 'Start of timeframe to examine (epochms)', dataType='integer', required=True)
+        .param('endTime', 'End of timeframe to examine (epochms)', dataType='integer', required=True)
+        .param('zoomThreshold', 'Maximum distance zoom variable can be from an interger', dataType='float', default='0.001', required=False)
+        .pagingParams(defaultSort='epochms', defaultSortDir=SortDir.DESCENDING)
+        .errorResponse()
+    )
+    def pan_history_json(self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort):
+        return self.activity_rois(imageId, startTime, endTime, zoomThreshold, limit, offset, sort)

--- a/annotation_tracker/rest.py
+++ b/annotation_tracker/rest.py
@@ -1,35 +1,35 @@
+from math import ceil, floor
+
+import large_image
+import numpy as np
 from bson.objectid import ObjectId
 from girder.api import access
-from girder.constants import TokenScope, SortDir
+from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource, setRawResponse, setResponseHeader
-from girder.api.describe import autoDescribeRoute, Description
+from girder.constants import SortDir, TokenScope
+from girder_large_image.models.image_item import ImageItem
+from PIL import Image
 
 from .models import Activity
-
-from girder_large_image.models.image_item import ImageItem
-import large_image
-
-from PIL import Image
-import io
-import numpy as np
-from math import floor, ceil
 
 
 class AnnotationTrackerResource(Resource):
     def __init__(self):
         super().__init__()
-        self.resourceName = 'annotation_tracker'
+        self.resourceName = "annotation_tracker"
 
-        self.route('POST', ('log', ), self.logActivity)
-        self.route('GET', (), self.find)
-        self.route('GET', ('pan_history', ), self.pan_history)
-        self.route('GET', ('pan_history_json', ), self.pan_history_json)
+        self.route("POST", ("log",), self.logActivity)
+        self.route("GET", (), self.find)
+        self.route("GET", ("pan_history",), self.pan_history)
+        self.route("GET", ("pan_history_json",), self.pan_history_json)
 
     @autoDescribeRoute(
-        Description('Log activity to the database.')
-        .notes('The return value is a dictionary of session identifiers, each '
-               'with a list of sequenceIds that were logged.')
-        .jsonParam('activityList', 'The key to reimport.', paramType='body')
+        Description("Log activity to the database.")
+        .notes(
+            "The return value is a dictionary of session identifiers, each "
+            "with a list of sequenceIds that were logged."
+        )
+        .jsonParam("activityList", "The key to reimport.", paramType="body")
     )
     @access.public
     def logActivity(self, activityList):
@@ -72,137 +72,199 @@ class AnnotationTrackerResource(Resource):
         saved = Activity().createActivityList(activityList)
         results = {}
         for entry in saved:
-            results.setdefault(entry['session'], set()).add(entry['sequenceId'])
+            results.setdefault(entry["session"], set()).add(entry["sequenceId"])
         for key in list(results.keys()):
             results[key] = sorted(results[key])
         return results
 
     @access.admin(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
-        Description('List or search for activities.')
-        .responseClass('Activity', array=True)
-        .param('sessionId', 'A session id', required=False)
-        .param('userId', 'A user id', required=False)
-        .param('activity', 'An activity string', required=False)
-        .jsonParam('query', 'Find activities that match this Mongo query.',
-                   required=False, requireObject=True)
-        .pagingParams(defaultSort='epochms', defaultSortDir=SortDir.DESCENDING)
+        Description("List or search for activities.")
+        .responseClass("Activity", array=True)
+        .param("sessionId", "A session id", required=False)
+        .param("userId", "A user id", required=False)
+        .param("activity", "An activity string", required=False)
+        .jsonParam(
+            "query",
+            "Find activities that match this Mongo query.",
+            required=False,
+            requireObject=True,
+        )
+        .pagingParams(defaultSort="epochms", defaultSortDir=SortDir.DESCENDING)
         .errorResponse()
     )
     def find(self, sessionId, userId, activity, query, limit, offset, sort):
         """Get a list of activities with given search parameters."""
         query = query or {}
         if sessionId:
-            query['session'] = sessionId
+            query["session"] = sessionId
         if userId:
-            query['userId'] = userId
+            query["userId"] = userId
         if activity:
-            query['activity'] = activity
+            query["activity"] = activity
         return Activity().find(query, offset=offset, limit=limit, sort=sort)
 
-    def activity_rois(self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort):
+    def activity_rois(
+        self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort
+    ):
         """Get a list of pan events for a given image and time range."""
         query = {
-            'currentImage': imageId,
-            'epochms': {'$gte': startTime, '$lte': endTime},
-            'activity': 'pan',
+            "currentImage": imageId,
+            "epochms": {"$gte": startTime, "$lte": endTime},
+            "activity": "pan",
         }
-        events = Activity().find(query, offset=offset, limit=limit, sort=sort, fields=['epochms', 'visibleArea', 'zoom'])
+        events = Activity().find(
+            query,
+            offset=offset,
+            limit=limit,
+            sort=sort,
+            fields=["epochms", "visibleArea", "zoom"],
+        )
         if events.count() == 0:
             return None
 
         # filter out events that are not close to an integer zoom
         def zoom_threshold(zoom):
             return abs(zoom - round(zoom)) < zoomThreshold
-        events = [e for e in events if zoom_threshold(e['zoom'])]
+
+        events = [e for e in events if zoom_threshold(e["zoom"])]
 
         return events
 
     @access.admin(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
-        Description('Generate image thumbnail displaying HistomicsUI panning history.')
-        .param('imageId', 'Image\'s item id', required=True)
-        .param('startTime', 'Start of timeframe to examine (epochms)', dataType='integer', required=True)
-        .param('endTime', 'End of timeframe to examine (epochms)', dataType='integer', required=True)
-        .param('zoomThreshold', 'Maximum distance zoom variable can be from an interger', dataType='float', default='0.001', required=False)
-        .pagingParams(defaultSort='epochms', defaultSortDir=SortDir.DESCENDING)
+        Description("Generate image thumbnail displaying HistomicsUI panning history.")
+        .param("imageId", "Image's item id", required=True)
+        .param(
+            "startTime",
+            "Start of timeframe to examine (epochms)",
+            dataType="integer",
+            required=True,
+        )
+        .param(
+            "endTime",
+            "End of timeframe to examine (epochms)",
+            dataType="integer",
+            required=True,
+        )
+        .param(
+            "zoomThreshold",
+            "Maximum distance zoom variable can be from an interger",
+            dataType="float",
+            default="0.001",
+            required=False,
+        )
+        .pagingParams(defaultSort="epochms", defaultSortDir=SortDir.DESCENDING)
         .errorResponse()
     )
-    def pan_history(self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort):
-        events = self.activity_rois(imageId, startTime, endTime, zoomThreshold, limit, offset, sort)
+    def pan_history(
+        self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort
+    ):
+        events = self.activity_rois(
+            imageId, startTime, endTime, zoomThreshold, limit, offset, sort
+        )
         if not events:
             return None
 
-        image = ImageItem().findOne({'_id': ObjectId(imageId)})
+        image = ImageItem().findOne({"_id": ObjectId(imageId)})
         meta = ImageItem().getMetadata(image)
-        if not meta or 'sizeX' not in meta:
+        if not meta or "sizeX" not in meta:
             return None
 
         dest = large_image.new()
         scales = {}
 
         for e in events:
-            tl = e['visibleArea']['tl']
-            br = e['visibleArea']['br']
+            tl = e["visibleArea"]["tl"]
+            br = e["visibleArea"]["br"]
 
             # assuming that we know the image size and can zero-out negative values
-            min_x, max_x = max(floor(tl['x']), 0), max(ceil(br['x']), 0)
-            min_y, max_y = max(floor(tl['y']), 0), max(ceil(br['y']), 0)
+            min_x, max_x = max(floor(tl["x"]), 0), max(ceil(br["x"]), 0)
+            min_y, max_y = max(floor(tl["y"]), 0), max(ceil(br["y"]), 0)
 
-            zoom = e['zoom']
+            zoom = e["zoom"]
             if zoom not in scales:
                 scales[zoom] = {
-                    'region': {'left': min_x, 'right': max_x, 'top': min_y, 'bottom': max_y},
-                    'mask': np.zeros((meta['sizeY'], meta['sizeX']), dtype='uint8')
+                    "region": {
+                        "left": min_x,
+                        "right": max_x,
+                        "top": min_y,
+                        "bottom": max_y,
+                    },
+                    "mask": np.zeros((meta["sizeY"], meta["sizeX"]), dtype="uint8"),
                 }
             else:
-                region = scales[zoom]['region']
-                scales[zoom]['region']['left']   = min(min_x, region['left'])
-                scales[zoom]['region']['right']  = max(max_x, region['right'])
-                scales[zoom]['region']['top']    = min(min_y, region['top'])
-                scales[zoom]['region']['bottom'] = max(max_y, region['bottom'])
+                region = scales[zoom]["region"]
+                scales[zoom]["region"]["left"] = min(min_x, region["left"])
+                scales[zoom]["region"]["right"] = max(max_x, region["right"])
+                scales[zoom]["region"]["top"] = min(min_y, region["top"])
+                scales[zoom]["region"]["bottom"] = max(max_y, region["bottom"])
 
             # set the mask for this region
-            scales[zoom]['mask'][min_y:max_y, min_x:max_x] = 1
+            scales[zoom]["mask"][min_y:max_y, min_x:max_x] = 1
 
         for zoom in sorted(scales.keys()):
             item = scales[zoom]
-            region = item['region']
+            region = item["region"]
 
             # assuming that the default scaling for the image is 20x (on zoom=4)
-            effective_mag = (meta.get('magnification', 20) / 2**4) * (2 ** zoom)
+            effective_mag = (meta.get("magnification", 20) / 2**4) * (2**zoom)
 
             nparray, mime_type = ImageItem().getRegion(
                 image,
                 region=region,
                 resample=Image.Resampling.NEAREST,
-                scale={'magnification': effective_mag},
+                scale={"magnification": effective_mag},
                 format=large_image.constants.TILE_FORMAT_NUMPY,
             )
 
-            upscale_factor = 2 ** (meta['levels'] - 1 - zoom)
-            nparray = nparray.repeat(upscale_factor, axis=0).repeat(upscale_factor, axis=1)
+            upscale_factor = 2 ** (meta["levels"] - 1 - zoom)
+            nparray = nparray.repeat(upscale_factor, axis=0).repeat(
+                upscale_factor, axis=1
+            )
 
-            mask = item['mask'][region['top']:region['bottom'], region['left']:region['right']]
-            mask = mask.copy() # copy to avoid modifying the original in resize
+            mask = item["mask"][
+                region["top"] : region["bottom"], region["left"] : region["right"]
+            ]
+            mask = mask.copy()  # copy to avoid modifying the original in resize
             mask.resize(nparray.shape[:2])
 
-            dest.addTile(nparray, x=region['left'], y=region['top'], mask=mask)
+            dest.addTile(nparray, x=region["left"], y=region["top"], mask=mask)
 
         data, mime = dest.getRegion()
-        setResponseHeader('Content-Type', mime)
+        setResponseHeader("Content-Type", mime)
         setRawResponse()
         return data
 
     @access.admin(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
-        Description('Return JSON list of ROI bounding boxes for given image/timeframe.')
-        .param('imageId', 'Image\'s item id', required=True)
-        .param('startTime', 'Start of timeframe to examine (epochms)', dataType='integer', required=True)
-        .param('endTime', 'End of timeframe to examine (epochms)', dataType='integer', required=True)
-        .param('zoomThreshold', 'Maximum distance zoom variable can be from an interger', dataType='float', default='0.001', required=False)
-        .pagingParams(defaultSort='epochms', defaultSortDir=SortDir.DESCENDING)
+        Description("Return JSON list of ROI bounding boxes for given image/timeframe.")
+        .param("imageId", "Image's item id", required=True)
+        .param(
+            "startTime",
+            "Start of timeframe to examine (epochms)",
+            dataType="integer",
+            required=True,
+        )
+        .param(
+            "endTime",
+            "End of timeframe to examine (epochms)",
+            dataType="integer",
+            required=True,
+        )
+        .param(
+            "zoomThreshold",
+            "Maximum distance zoom variable can be from an interger",
+            dataType="float",
+            default="0.001",
+            required=False,
+        )
+        .pagingParams(defaultSort="epochms", defaultSortDir=SortDir.DESCENDING)
         .errorResponse()
     )
-    def pan_history_json(self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort):
-        return self.activity_rois(imageId, startTime, endTime, zoomThreshold, limit, offset, sort)
+    def pan_history_json(
+        self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort
+    ):
+        return self.activity_rois(
+            imageId, startTime, endTime, zoomThreshold, limit, offset, sort
+        )

--- a/annotation_tracker/rest.py
+++ b/annotation_tracker/rest.py
@@ -140,11 +140,10 @@ class AnnotationTrackerResource(Resource):
 
             roi = {"top": tl["y"], "left": tl["x"], "bottom": br["y"], "right": br["x"]}
             roi = {k: max(0, int(v)) for k, v in roi.items()}  # clamp pixels to be greater than 0
-            # this is needed for getRegion
+                                                               # this is needed for getRegion
             roi["epochms"] = e["epochms"]
 
-            zoom = e["zoom"]
-            # TODO: zooms are still not necessarily the same if they meet the zoom_threshold -> make sure to pool the correct ones together
+            zoom = e["rounded_zoom"]
             if zoom not in scales:
                 scales[zoom] = {"rois": [roi]}
             else:
@@ -185,7 +184,12 @@ class AnnotationTrackerResource(Resource):
         def zoom_threshold(zoom):
             return abs(zoom - round(zoom)) < zoomThreshold
 
-        events = [e for e in events if zoom_threshold(e["zoom"])]
+        # filter events based on zoom value proximity & store the rounded zoom value
+        events = [
+            {**e, "rounded_zoom": round(e["zoom"])}
+            for e in events
+            if zoom_threshold(e["zoom"])
+        ]
 
         return events
 

--- a/annotation_tracker/rest.py
+++ b/annotation_tracker/rest.py
@@ -430,7 +430,7 @@ class AnnotationTrackerResource(Resource):
             file_path = os.path.join(tempdir, file_name)
 
             with open(file_path, "w") as yml_file:
-                yml_file.write(f"---\n{yaml.dump({"sources": source_list})}")
+                yml_file.write(f"---\n{yaml.dump({'sources': source_list})}")
 
             with open(file_path, "rb") as yml_file:
                 return Upload().uploadFromFile(

--- a/annotation_tracker/rest.py
+++ b/annotation_tracker/rest.py
@@ -162,7 +162,7 @@ class AnnotationTrackerResource(Resource):
         return scales
 
     def activity_rois(
-        self, imageId, startTime, endTime, zoomThreshold, limit, offset, sort
+        self, imageId, startTime, endTime, zoomPrecision, limit, offset, sort
     ):
         """Get a list of pan events for a given image and time range."""
         query = {
@@ -182,7 +182,7 @@ class AnnotationTrackerResource(Resource):
 
         # filter out events that are not close to an integer zoom
         def zoom_threshold(zoom):
-            return abs(zoom - round(zoom)) < zoomThreshold
+            return abs(zoom - round(zoom)) < zoomPrecision
 
         # filter events based on zoom value proximity & store the rounded zoom value
         events = [
@@ -211,8 +211,8 @@ class AnnotationTrackerResource(Resource):
             required=True,
         )
         .param(
-            "zoomThreshold",
-            "Maximum distance zoom variable can be from an interger",
+            "zoomPrecision",
+            "Maximum deviance zoom variable can be from a round interger value",
             dataType="float",
             default="0.001",
             required=False,
@@ -228,10 +228,10 @@ class AnnotationTrackerResource(Resource):
         .errorResponse()
     )
     def pan_history(
-        self, imageId, destFolder, startTime, endTime, zoomThreshold, areaThreshold, limit, offset, sort
+        self, imageId, destFolder, startTime, endTime, zoomPrecision, areaThreshold, limit, offset, sort
     ):
         events = self.activity_rois(
-            imageId, startTime, endTime, zoomThreshold, limit, offset, sort
+            imageId, startTime, endTime, zoomPrecision, limit, offset, sort
         )
         if not events:
             return None
@@ -367,7 +367,7 @@ class AnnotationTrackerResource(Resource):
             required=True,
         )
         .param(
-            "zoomThreshold",
+            "zoomPrecision",
             "Maximum distance zoom variable can be from an interger",
             dataType="float",
             default="0.001",
@@ -384,7 +384,7 @@ class AnnotationTrackerResource(Resource):
         .errorResponse()
     )
     def pan_history_json(
-        self, imageId, startTime, endTime, zoomThreshold, areaThreshold, limit, offset, sort
+        self, imageId, startTime, endTime, zoomPrecision, areaThreshold, limit, offset, sort
     ):
-        events = self.activity_rois(imageId, startTime, endTime, zoomThreshold, limit, offset, sort)
+        events = self.activity_rois(imageId, startTime, endTime, zoomPrecision, limit, offset, sort)
         return self.spatial_downsample(events, threshold=areaThreshold)

--- a/annotation_tracker/rest.py
+++ b/annotation_tracker/rest.py
@@ -219,7 +219,7 @@ class AnnotationTrackerResource(Resource):
         )
         .param(
             "areaThreshold",
-            "Minimum ratio of (rectangle area overlap / rectangle area) before resampling occurs",
+            "Used in spatial ROI downsampling. Minimum ratio of (ROI rectangle area overlap / rectangle area) before resample occurs",
             dataType="float",
             default="0.95",
             required=False,


### PR DESCRIPTION
Added `pan_history` and `pan_history_json` endpoints which track and extract regions of interest stored by annotation-tracker; the former creates a synthesized thumbnail of the regions, the latter produces the raw JSON ROI data. Query the data with a given `imageId` and start/end times.